### PR TITLE
Update quickstart with env configuration

### DIFF
--- a/docs/swarms/install/quickstart.md
+++ b/docs/swarms/install/quickstart.md
@@ -11,6 +11,24 @@
   WORKSPACE_DIR="agent_workspace"
   ```
 
+### Configure Environment Variables
+
+Create a `.env` file in your project root and add your provider keys along with
+the workspace directory:
+
+```bash
+OPENAI_API_KEY="your-openai-key"
+WORKSPACE_DIR="agent_workspace"
+```
+
+Load these variables before running an agent:
+
+```python
+from dotenv import load_dotenv
+load_dotenv()
+
+```
+
 ### **Installation**
 
 To install Swarms, run:


### PR DESCRIPTION
## Summary
- document how to configure environment variables for swarms

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68431c43a5dc83298ac19b552f2695b4