### PR TITLE
Fix field_validator syntax for Pydantic v2

### DIFF
--- a/swarms/structs/agent_rag_handler.py
+++ b/swarms/structs/agent_rag_handler.py
@@ -49,7 +49,7 @@ class RAGConfig(BaseModel):
         default=None, description="Keywords to check for relevance"
     )
 
-    @field_validator("relevance_keywords", pre=True)
+    @field_validator("relevance_keywords", mode="before")
     def set_default_keywords(cls, v):
         if v is None:
             return [
@@ -227,9 +227,12 @@ class AgentRAGHandler:
         formatted_sections = [header]
 
         for i, result in enumerate(results, 1):
-            content, score, source, metadata = (
-                self._extract_result_fields(result)
-            )
+            (
+                content,
+                score,
+                source,
+                metadata,
+            ) = self._extract_result_fields(result)
 
             section = f"""
 [Memory {i}] Relevance: {score} | Source: {source}


### PR DESCRIPTION
## Summary
- ensure RAG handler uses the Pydantic v2 field_validator API

## Testing
- `black swarms/structs/agent_rag_handler.py`
- `pytest tests/utils/test_try_except_wrapper.py::test_try_except_wrapper_success -q` *(fails: ModuleNotFoundError: No module named 'swarms')*

------
https://chatgpt.com/codex/tasks/task_e_6849adfb9ab48329964c7d1900a13337