### PR TITLE
Fix asyncio loop handling in MCP client

### DIFF
--- a/swarms/tools/mcp_client_call.py
+++ b/swarms/tools/mcp_client_call.py
@@ -192,21 +192,21 @@ def retry_with_backoff(retries=3, backoff_in_seconds=1):
 
 
 @contextlib.contextmanager
-def get_or_create_event_loop():
-    """Context manager to handle event loop creation and cleanup."""
+def get_or_create_event_loop() -> asyncio.AbstractEventLoop:
+    """Return an event loop and ensure proper cleanup."""
+    created = False
     try:
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
     except RuntimeError:
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
+        created = True
 
     try:
         yield loop
     finally:
-        # Only close the loop if we created it and it's not the main event loop
-        if loop != asyncio.get_event_loop() and not loop.is_running():
-            if not loop.is_closed():
-                loop.close()
+        if created and not loop.is_closed():
+            loop.close()
 
 
 def connect_to_mcp_server(connection: MCPConnection = None):

--- a/tests/tools/test_mcp_client_call.py
+++ b/tests/tools/test_mcp_client_call.py
@@ -1,0 +1,37 @@
+import asyncio
+import ast
+from pathlib import Path
+
+# Extract function source using AST to avoid importing entire package
+source_text = Path("swarms/tools/mcp_client_call.py").read_text()
+module = ast.parse(source_text)
+func_source = None
+for node in module.body:
+    if isinstance(node, ast.FunctionDef) and node.name == "get_or_create_event_loop":
+        start = node.decorator_list[0].lineno if node.decorator_list else node.lineno
+        end = node.end_lineno
+        func_source = "\n".join(source_text.splitlines()[start - 1 : end])
+        break
+assert func_source, "Function not found"
+namespace = {"asyncio": asyncio, "contextlib": __import__("contextlib")}
+exec(func_source, namespace)
+get_or_create_event_loop = namespace["get_or_create_event_loop"]
+
+
+def test_get_or_create_event_loop_creates_and_closes():
+    with get_or_create_event_loop() as loop:
+        assert isinstance(loop, asyncio.AbstractEventLoop)
+        created = loop
+    assert created.is_closed()
+
+
+def test_get_or_create_event_loop_uses_existing_loop():
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        with get_or_create_event_loop() as returned:
+            assert isinstance(returned, asyncio.AbstractEventLoop)
+        assert not loop.is_closed()
+    finally:
+        loop.close()
+        asyncio.set_event_loop(asyncio.new_event_loop())


### PR DESCRIPTION
## Summary
- fix `get_or_create_event_loop` to properly close newly created loops
- add regression tests for event loop helper

## Testing
- `pytest -q tests/tools/test_mcp_client_call.py`

------
https://chatgpt.com/codex/tasks/task_e_6849c11dbb8c8329b0e1f6b6afbb958b

<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--24.org.readthedocs.build/en/24/

<!-- readthedocs-preview swarms end -->