### PR TITLE
Fix interactive_groupchat system prompt display

### DIFF
--- a/swarms/structs/interactive_groupchat.py
+++ b/swarms/structs/interactive_groupchat.py
@@ -223,7 +223,7 @@ class InteractiveGroupChat:
         for name, agent in self.agent_map.items():
             if isinstance(agent, Agent):
                 print(
-                    f"- @{name}: {agent.system_prompt.split('\n')[0]}"
+                    f"- @{name}: {agent.system_prompt.splitlines()[0]}"
                 )
             else:
                 print(f"- @{name}: Custom callable function")


### PR DESCRIPTION
## Summary
- use `splitlines()[0]` when displaying the agent system prompt in the interactive group chat

## Testing
- `python -m py_compile swarms/structs/interactive_groupchat.py`
