### PR TITLE
Add Deep Research news aggregator example

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -347,6 +347,7 @@ nav:
       - MixtureOfAgents Example: "swarms/examples/mixture_of_agents.md"
       - Unique Swarms: "swarms/examples/unique_swarms.md"
       - Agents as Tools: "swarms/examples/agents_as_tools.md"
+      - Deep Research News Aggregator: "swarms/examples/deep_research_news_aggregator.md"
       - Applications:
         - Swarms DAO: "swarms/examples/swarms_dao.md"
         - Swarms of Browser Agents: "swarms/examples/swarms_of_browser_agents.md"

--- a/docs/swarms/examples/deep_research_news_aggregator.md
+++ b/docs/swarms/examples/deep_research_news_aggregator.md
@@ -1,0 +1,29 @@
+# Deep Research News Aggregator
+
+This example demonstrates how to use the **DeepResearchSwarm** to gather and summarize recent news. The swarm automatically generates search queries, collects information in parallel, and returns a concise summary.
+
+## Installation
+
+```bash
+pip install swarms
+```
+
+## Code
+
+```python
+from swarms.structs.deep_research_swarm import DeepResearchSwarm
+
+swarm = DeepResearchSwarm(
+    name="News Research Swarm",
+    description="Aggregates and summarizes recent technology and finance news",
+    output_type="string",
+)
+
+result = swarm.run(
+    "Provide a concise summary of today's most important technology and finance news."
+)
+
+print(result)
+```
+
+Running the script will print a short digest of the latest technology and finance headlines.

--- a/examples/news/deep_research_news_aggregator.py
+++ b/examples/news/deep_research_news_aggregator.py
@@ -1,0 +1,23 @@
+from swarms.structs.deep_research_swarm import DeepResearchSwarm
+
+
+def main() -> None:
+    """Gather and summarize current technology and finance news."""
+    swarm = DeepResearchSwarm(
+        name="News Research Swarm",
+        description="Aggregates and summarizes recent technology and finance news",
+        output_type="string",
+    )
+
+    query = (
+        "Provide a concise summary of today's most important technology and finance news."
+    )
+
+    result = swarm.run(query)
+
+    print("\nNews Summary:\n")
+    print(result)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- provide a deep research swarm script for gathering and summarizing news
- document how to use the deep research news aggregator
- add docs entry linking to the new example

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_684b05493f908329800b19acfb5f3451

<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--28.org.readthedocs.build/en/28/

<!-- readthedocs-preview swarms end -->