### PR TITLE
Add multiple MCP execution example

### DIFF
--- a/docs/examples/multiple_mcp_tool_execution.md
+++ b/docs/examples/multiple_mcp_tool_execution.md
@@ -1,0 +1,38 @@
+# Multiple MCP Tool Execution Example
+
+This example demonstrates how to connect an `Agent` to more than one Model Context Protocol (MCP) server and execute multiple tool payloads in a single run.
+
+## Prerequisites
+
+- Python 3.8+
+- `swarms` package installed
+- Two running MCP servers (for example on ports `8000` and `8001`)
+
+## Code
+
+```python
+from swarms import Agent
+
+MCP_SERVERS = [
+    "http://0.0.0.0:8000/sse",
+    "http://0.0.0.0:8001/sse",
+]
+
+agent = Agent(
+    agent_name="Multi-MCP-Agent",
+    agent_description="Demonstration agent using multiple MCP servers",
+    max_loops=1,
+    mcp_urls=MCP_SERVERS,
+    output_type="all",
+)
+
+payloads = [
+    {"function": {"name": "get_crypto_price", "arguments": {"coin_id": "bitcoin"}}},
+    {"function": {"name": "get_crypto_price", "arguments": {"coin_id": "ethereum"}}},
+]
+
+results = agent.execute_multiple_mcp_payloads(payloads)
+print(results)
+```
+
+The complete script can be found at [`examples/tools/mcp_examples/multiple_mcp_execution.py`](../../examples/tools/mcp_examples/multiple_mcp_execution.py).

--- a/docs/swarms/structs/agent_mcp.md
+++ b/docs/swarms/structs/agent_mcp.md
@@ -62,7 +62,7 @@ The **Model Context Protocol (MCP)** integration enables Swarms agents to dynami
     | Feature | Status | Expected |
     |---------|--------|----------|
     | **MCPConnection Model** | 🚧 Development | Q1 2024 |
-    | **Multiple Server Support** | 🚧 Planned | Q2 2024 |
+    | **Multiple Server Support** | ✅ Ready | Connect to multiple MCPs |
     | **Parallel Function Calling** | 🚧 Research | Q2 2024 |
     | **Auto-discovery** | 🚧 Planned | Q3 2024 |
 
@@ -406,19 +406,22 @@ graph TD
     mcp_url = "http://server:8000/sse"
     ```
 
-    ### 🚧 Single Server Limitation
-    
-    Currently supports one server per agent:
-    
+    ### Multiple Servers
+
+    Connect to several MCP servers with the `mcp_urls` parameter:
+
     ```python
-    # ❌ Multiple servers not supported
-    mcp_servers = [
-        "http://server1:8000/sse",
-        "http://server2:8000/sse"
-    ]
-    
-    # ✅ Single server only
-    mcp_url = "http://primary-server:8000/sse"
+    agent = Agent(
+        agent_name="Multi-MCP-Agent",
+        mcp_urls=[
+            "http://server1:8000/sse",
+            "http://server2:8000/sse",
+        ],
+        max_loops=1,
+    )
+
+    payloads = [...]
+    result = agent.execute_multiple_mcp_payloads(payloads)
     ```
 
     ### 🚧 Sequential Execution

--- a/examples/tools/mcp_examples/multiple_mcp_execution.py
+++ b/examples/tools/mcp_examples/multiple_mcp_execution.py
@@ -1,0 +1,27 @@
+from swarms import Agent
+
+# List of MCP server URLs
+MCP_SERVERS = [
+    "http://0.0.0.0:8000/sse",
+    "http://0.0.0.0:8001/sse",
+]
+
+# Initialize the agent with multiple MCP servers
+agent = Agent(
+    agent_name="Multi-MCP-Agent",
+    agent_description="Demonstration agent using multiple MCP servers",
+    max_loops=1,
+    mcp_urls=MCP_SERVERS,
+    output_type="all",
+)
+
+# Example payloads for each server
+payloads = [
+    {"function": {"name": "get_crypto_price", "arguments": {"coin_id": "bitcoin"}}},
+    {"function": {"name": "get_crypto_price", "arguments": {"coin_id": "ethereum"}}},
+]
+
+# Execute the payloads across the MCP servers
+results = agent.execute_multiple_mcp_payloads(payloads)
+
+print(results)


### PR DESCRIPTION
## Summary
- add multiple MCP execution example script
- document multi-server agent usage in docs/examples
- update MCP integration guide with multi-server instructions

## Testing
- `pytest -q` *(fails: 65 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_684c8a757c688329be53a4054e53dbb2