### PR TITLE
Add multi-MCP execution example

### DIFF
--- a/docs/examples/multiple_mcp_tool_execution.md
+++ b/docs/examples/multiple_mcp_tool_execution.md
@@ -2,19 +2,34 @@
 
 This example demonstrates how an agent can sequentially run tools exposed by different MCP servers.
 
+First start the two MCP servers provided in the examples:
+
+```bash
+python examples/tools/mcp_examples/servers/mcp_test.py
+python examples/tools/mcp_examples/servers/okx_crypto_server.py
+```
+
+Then start the lightweight servers that return the payloads for each tool:
+
+```bash
+python examples/tools/mcp_examples/servers/payload_server_one.py
+python examples/tools/mcp_examples/servers/payload_server_two.py
+```
+
+Finally run the client agent:
+
+```bash
+python examples/tools/mcp_examples/multiple_mcp_client.py
+```
+
+The client uses `Agent.execute_multiple_mcp_payloads()` with two URLs:
+
 ```python
 from swarms import Agent
 
-# URLs can also come from the MCP_URLS environment variable
-urls = [
-    "http://0.0.0.0:8000/sse",
-    "http://0.0.0.0:8001/sse",
-]
-
+urls = ["http://0.0.0.0:9000", "http://0.0.0.0:9001"]
 agent = Agent(agent_name="Multi-MCP-Agent", mcp_urls=urls, max_loops=1)
-
-# Fetch each payload and execute the associated MCP tool
 agent.execute_multiple_mcp_payloads()
 ```
 
-Each MCP endpoint should return a JSON payload with `function_name`, `server_url` and optional `payload` data. The agent parses these values and calls `execute_mcp_call` for every entry.
+Each payload endpoint returns a JSON document containing `function_name`, `server_url` and an optional `payload`. The agent parses this data and calls `execute_mcp_call` on the specified MCP server.

--- a/docs/swarms/structs/agent.md
+++ b/docs/swarms/structs/agent.md
@@ -637,13 +637,15 @@ The `Agent` class can orchestrate tools across several MCP servers. Provide a li
 ```python
 from swarms import Agent
 
+urls = ["http://0.0.0.0:9000", "http://0.0.0.0:9001"]
+
 agent = Agent(
     agent_name="Multi-MCP-Agent",
     max_loops=1,
-    mcp_urls=["http://0.0.0.0:8000/sse", "http://0.0.0.0:8001/sse"],
+    mcp_urls=urls,
 )
 
 agent.execute_multiple_mcp_payloads()
 ```
 
-Each URL should return a JSON payload with `function_name`, `server_url`, and `payload` fields. The agent parses this response and calls `execute_mcp_call` for every entry.
+Each payload endpoint returns a JSON document with `function_name`, `server_url` and optional `payload` values. See `examples/tools/mcp_examples` for the full servers and client script.

--- a/docs/swarms/structs/agent_mcp.md
+++ b/docs/swarms/structs/agent_mcp.md
@@ -412,11 +412,13 @@ graph TD
 
     ```python
     mcp_urls = [
-        "http://server1:8000/sse",
-        "http://server2:8000/sse",
+        "http://0.0.0.0:9000",
+        "http://0.0.0.0:9001",
     ]
     agent = Agent(mcp_urls=mcp_urls)
     ```
+
+    See `examples/tools/mcp_examples` for runnable servers that demonstrate this feature.
 
     ### 🚧 Sequential Execution
     

--- a/examples/tools/mcp_examples/multiple_mcp_client.py
+++ b/examples/tools/mcp_examples/multiple_mcp_client.py
@@ -1,0 +1,13 @@
+from swarms import Agent
+
+urls = [
+    "http://0.0.0.0:9000",
+    "http://0.0.0.0:9001",
+]
+
+agent = Agent(
+    agent_name="Multi-MCP-Agent", mcp_urls=urls, max_loops=1
+)
+
+if __name__ == "__main__":
+    agent.execute_multiple_mcp_payloads()

--- a/examples/tools/mcp_examples/servers/payload_server_one.py
+++ b/examples/tools/mcp_examples/servers/payload_server_one.py
@@ -1,0 +1,19 @@
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import json
+
+
+class PayloadHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        payload = {
+            "function_name": "get_crypto_price",
+            "server_url": "http://0.0.0.0:8000/sse",
+            "payload": {"coin_id": "bitcoin"},
+        }
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps(payload).encode())
+
+
+if __name__ == "__main__":
+    HTTPServer(("0.0.0.0", 9000), PayloadHandler).serve_forever()

--- a/examples/tools/mcp_examples/servers/payload_server_two.py
+++ b/examples/tools/mcp_examples/servers/payload_server_two.py
@@ -1,0 +1,19 @@
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import json
+
+
+class PayloadHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        payload = {
+            "function_name": "get_okx_crypto_price",
+            "server_url": "http://0.0.0.0:8001/sse",
+            "payload": {"symbol": "BTC-USDT"},
+        }
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps(payload).encode())
+
+
+if __name__ == "__main__":
+    HTTPServer(("0.0.0.0", 9001), PayloadHandler).serve_forever()


### PR DESCRIPTION
## Summary
- add payload servers and client example for multiple MCP execution
- document how to start the servers and run the client
- update Agent docs with revised example
- mention runnable example in agent MCP docs

## Testing
- `ruff check examples/tools/mcp_examples/servers/payload_server_one.py`
- `ruff check examples/tools/mcp_examples/servers/payload_server_two.py`
- `ruff check examples/tools/mcp_examples/multiple_mcp_client.py`
- `black examples/tools/mcp_examples/servers/payload_server_one.py examples/tools/mcp_examples/servers/payload_server_two.py examples/tools/mcp_examples/multiple_mcp_client.py -q`
- `pytest -q` *(fails: ModuleNotFoundError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_684daa45b7688329a59c40bc24ce92a3

<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--35.org.readthedocs.build/en/35/

<!-- readthedocs-preview swarms end -->