### PR TITLE
Add conversation history export docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,6 +491,19 @@ agent.model_dump_json()
 print(agent.to_toml())
 
 ```
+### Export Conversation History
+
+```python
+from swarms.structs.conversation import Conversation
+from swarms.utils.history_output_formatter import history_output_formatter
+
+conversation = Conversation()
+conversation.add("user", "Hello")
+conversation.add("assistant", "Hi!")
+
+yaml_history = history_output_formatter(conversation, type="yaml")
+xml_history = history_output_formatter(conversation, type="xml")
+```
 
 
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -281,6 +281,8 @@ nav:
         - Pinecone: "swarms_memory/pinecone.md"
         - Faiss: "swarms_memory/faiss.md"
 
+    - Utilities:
+      - History Output Formatter: "utils/history_output_formatter.md"
     - Deployment Solutions:
       - Deploy your Swarms on Google Cloud Run: "swarms_cloud/cloud_run.md"
       - Deploy your Swarms on Phala: "swarms_cloud/phala_deploy.md"

--- a/docs/utils/history_output_formatter.md
+++ b/docs/utils/history_output_formatter.md
@@ -1,0 +1,25 @@
+# history_output_formatter Utility
+
+The `history_output_formatter` function converts a `Conversation` object into various formats.
+It supports lists, dictionaries, strings, JSON, YAML, and XML.
+
+## Export to YAML
+
+```python
+from swarms.structs.conversation import Conversation
+from swarms.utils.history_output_formatter import history_output_formatter
+
+conversation = Conversation()
+conversation.add("user", "Hello")
+conversation.add("assistant", "Hi there!")
+
+yaml_history = history_output_formatter(conversation, type="yaml")
+print(yaml_history)
+```
+
+## Export to XML
+
+```python
+xml_history = history_output_formatter(conversation, type="xml")
+print(xml_history)
+```

--- a/examples/conversation_export/export_to_yaml_xml.py
+++ b/examples/conversation_export/export_to_yaml_xml.py
@@ -1,0 +1,15 @@
+from swarms.structs.conversation import Conversation
+from swarms.utils.history_output_formatter import history_output_formatter
+
+# Create a simple conversation
+conversation = Conversation()
+conversation.add("user", "Hello")
+conversation.add("assistant", "Hi there!")
+
+# Export the conversation to YAML
+yaml_output = history_output_formatter(conversation, type="yaml")
+print("YAML Format:\n", yaml_output)
+
+# Export the conversation to XML
+xml_output = history_output_formatter(conversation, type="xml")
+print("\nXML Format:\n", xml_output)


### PR DESCRIPTION
## Summary
- document `history_output_formatter` and add usage for YAML/XML export
- provide example script exporting conversation history in both formats
- mention export feature in README and mkdocs navigation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684dd4f8ef7c832993a9906150459db9

<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--36.org.readthedocs.build/en/36/

<!-- readthedocs-preview swarms end -->