### PR TITLE
Add multiple MCP support

### DIFF
--- a/docs/examples/multi_mcp_execution.md
+++ b/docs/examples/multi_mcp_execution.md
@@ -1,0 +1,25 @@
+# Multi MCP Execution Example
+
+This example demonstrates using a list of MCP servers with an `Agent`.
+
+```python
+import os
+from swarms import Agent
+
+# Configure multiple MCP URLs
+os.environ["MCP_URLS"] = "http://localhost:8000/sse,http://localhost:9001/sse"
+
+agent = Agent(
+    agent_name="Multi-MCP-Agent",
+    model_name="gpt-4o-mini",
+    max_loops=1,
+)
+
+# Example payloads produced by your model
+payloads = [
+    {"function_name": "get_weather", "server_url": "http://localhost:8000/sse", "payload": {"city": "London"}},
+    {"function_name": "get_news", "server_url": "http://localhost:9001/sse", "payload": {"topic": "ai"}},
+]
+
+agent.handle_multiple_mcp_tools(agent.mcp_urls, payloads)
+```

--- a/docs/swarms/structs/agent.md
+++ b/docs/swarms/structs/agent.md
@@ -478,6 +478,41 @@ agent.model_dump_json()
 print(agent.to_toml())
 ```
 
+### Multi-MCP Tool Execution
+
+Execute tools from multiple MCP servers by providing a list of URLs via the
+`mcp_urls` parameter or the `MCP_URLS` environment variable.
+
+```python
+import os
+from swarms import Agent
+
+# Using an environment variable for server configuration
+os.environ["MCP_URLS"] = "http://localhost:8000/sse,http://localhost:9001/sse"
+
+agent = Agent(
+    agent_name="Multi-MCP-Agent",
+    model_name="gpt-4o-mini",
+    max_loops=1,
+)
+
+# Example MCP payloads returned by your model
+mcp_payloads = [
+    {
+        "function_name": "get_price",
+        "server_url": "http://localhost:8000/sse",
+        "payload": {"symbol": "BTC"},
+    },
+    {
+        "function_name": "market_sentiment",
+        "server_url": "http://localhost:9001/sse",
+        "payload": {"symbol": "BTC"},
+    },
+]
+
+agent.handle_multiple_mcp_tools(agent.mcp_urls, mcp_payloads)
+```
+
 ## Auto Generate Prompt + CPU Execution
 
 

--- a/docs/swarms/structs/agent_mcp.md
+++ b/docs/swarms/structs/agent_mcp.md
@@ -62,7 +62,7 @@ The **Model Context Protocol (MCP)** integration enables Swarms agents to dynami
     | Feature | Status | Expected |
     |---------|--------|----------|
     | **MCPConnection Model** | 🚧 Development | Q1 2024 |
-    | **Multiple Server Support** | 🚧 Planned | Q2 2024 |
+    | **Multiple Server Support** | ✅ Ready | - |
     | **Parallel Function Calling** | 🚧 Research | Q2 2024 |
     | **Auto-discovery** | 🚧 Planned | Q3 2024 |
 
@@ -124,6 +124,26 @@ The **Model Context Protocol (MCP)** integration enables Swarms agents to dynami
         verbose=True,
     )
     ```
+
+---
+
+### MCP Payload Format
+
+When the agent generates a function call for an MCP tool it should return a
+payload in the following format:
+
+```json
+[
+  {
+    "function_name": "tool_name",
+    "server_url": "http://server:8000/sse",
+    "payload": {"arg": "value"}
+  }
+]
+```
+
+Use `handle_multiple_mcp_tools` to execute each payload across the configured
+servers.
 
 ---
 
@@ -214,7 +234,10 @@ graph TD
         agent_name="Crypto-Trading-Agent",
         agent_description="Real-time cryptocurrency market analyzer",
         max_loops=2,
-        mcp_url="http://crypto-server:8000/sse",
+        mcp_urls=[
+            "http://crypto-server:8000/sse",
+            "http://backup-server:8001/sse",
+        ],
         output_type="json",
         temperature=0.1,
     )
@@ -406,19 +429,17 @@ graph TD
     mcp_url = "http://server:8000/sse"
     ```
 
-    ### 🚧 Single Server Limitation
-    
-    Currently supports one server per agent:
-    
+    ### ✅ Multiple Server Support
+
+    Agents can now connect to multiple MCP servers. Provide a list of URLs via
+    the `mcp_urls` parameter or set the environment variable `MCP_URLS`.
+
     ```python
-    # ❌ Multiple servers not supported
-    mcp_servers = [
+    mcp_urls = [
         "http://server1:8000/sse",
-        "http://server2:8000/sse"
+        "http://server2:8000/sse",
     ]
-    
-    # ✅ Single server only
-    mcp_url = "http://primary-server:8000/sse"
+    agent = Agent(mcp_urls=mcp_urls)
     ```
 
     ### 🚧 Sequential Execution
@@ -688,7 +709,7 @@ graph TD
         - **Connection Pooling** - Improved performance
 
     === "2 Week"
-        - **Multiple Server Support** - Connect to multiple MCPs
+        - **Multiple Server Support** - *Completed*
         - **Parallel Execution** - Concurrent tool calling
         - **Load Balancing** - Distribute requests across servers
         - **Advanced Monitoring** - Real-time metrics

--- a/swarms/tools/__init__.py
+++ b/swarms/tools/__init__.py
@@ -30,6 +30,7 @@ from swarms.tools.json_utils import base_model_to_json
 from swarms.tools.mcp_client_call import (
     execute_tool_call_simple,
     _execute_tool_call_simple,
+    execute_mcp_call,
     get_tools_for_multiple_mcp_servers,
     get_mcp_tools_sync,
     aget_mcp_tools,
@@ -59,6 +60,7 @@ __all__ = [
     "base_model_to_json",
     "execute_tool_call_simple",
     "_execute_tool_call_simple",
+    "execute_mcp_call",
     "get_tools_for_multiple_mcp_servers",
     "get_mcp_tools_sync",
     "aget_mcp_tools",

--- a/tests/structs/test_multi_mcp.py
+++ b/tests/structs/test_multi_mcp.py
@@ -1,0 +1,38 @@
+import asyncio
+from swarms.structs.agent import Agent
+from swarms.structs.agent import execute_mcp_call
+from unittest.mock import patch
+
+
+def test_handle_multiple_mcp_tools():
+    agent = Agent(agent_name="Test", llm=None, max_loops=1)
+    urls = ["http://server1", "http://server2"]
+    payloads = [
+        {
+            "function_name": "tool1",
+            "server_url": "http://server1",
+            "payload": {"a": 1},
+        },
+        {
+            "function_name": "tool2",
+            "server_url": "http://server2",
+            "payload": {},
+        },
+    ]
+    called = []
+
+    async def fake_exec(
+        function_name, server_url, payload, *args, **kwargs
+    ):
+        called.append((function_name, server_url, payload))
+        return "ok"
+
+    with patch(
+        "swarms.structs.agent.execute_mcp_call", side_effect=fake_exec
+    ):
+        agent.handle_multiple_mcp_tools(urls, payloads)
+
+    assert called == [
+        ("tool1", "http://server1", {"a": 1}),
+        ("tool2", "http://server2", {}),
+    ]


### PR DESCRIPTION
## Summary
- add `execute_mcp_call` utility for direct MCP executions
- support multiple MCP URLs and env var `MCP_URLS`
- document multi‑MCP usage and payload format
- provide example `docs/examples/multi_mcp_execution.md`
- test new `handle_multiple_mcp_tools`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_684fef30a6bc8329bf1c2a07ed727f64