### PR TITLE
Add MultiAgentRouter minimal example

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -344,6 +344,7 @@ nav:
       - Group Chat Example: "swarms/examples/groupchat_example.md"
       - Sequential Workflow Example: "swarms/examples/sequential_example.md"
       - SwarmRouter Example: "swarms/examples/swarm_router.md"
+      - MultiAgentRouter Minimal Example: "swarms/examples/multi_agent_router_minimal.md"
       - ConcurrentWorkflow Example: "swarms/examples/concurrent_workflow.md"
       - MixtureOfAgents Example: "swarms/examples/mixture_of_agents.md"
       - Unique Swarms: "swarms/examples/unique_swarms.md"

--- a/docs/swarms/concept/swarm_architectures.md
+++ b/docs/swarms/concept/swarm_architectures.md
@@ -34,6 +34,7 @@ Swarm architectures leverage these communication patterns to ensure that agents 
 | Spreadsheet Swarm             | Manages tasks at scale, tracking agent outputs in a structured format like CSV files.                                                                                   | [Code Link](https://docs.swarms.world/en/latest/swarms/structs/spreadsheet_swarm/)                 | Large-scale marketing analytics, financial audits                                                 |
 | Forest Swarm                  | A swarm structure that organizes agents in a tree-like hierarchy for complex decision-making processes.                                                                 | [Code Link](https://docs.swarms.world/en/latest/swarms/structs/forest_swarm/)                      | Multi-stage workflows, hierarchical reinforcement learning                                        |
 | Swarm Router                  | Routes and chooses the swarm architecture based on the task requirements and available agents.                                                                        | [Code Link](https://docs.swarms.world/en/latest/swarms/structs/swarm_router/)                       | Dynamic task routing, adaptive swarm architecture selection, optimized agent allocation            |
+| MultiAgentRouter              | Boss agent selects the best agent for each task. | [Minimal Example](https://github.com/kyegomez/swarms/blob/master/examples/multi_agent/mar/multi_agent_router_minimal.py) | Task-specific agent routing |
 
 
 

--- a/docs/swarms/examples/multi_agent_router_minimal.md
+++ b/docs/swarms/examples/multi_agent_router_minimal.md
@@ -1,0 +1,27 @@
+# MultiAgentRouter Minimal Example
+
+This example shows how to route a task to the most suitable agent using `MultiAgentRouter`.
+
+```python
+from swarms import Agent, MultiAgentRouter
+
+agents = [
+    Agent(
+        agent_name="Researcher",
+        system_prompt="Answer questions briefly.",
+        model_name="gpt-4o-mini",
+    ),
+    Agent(
+        agent_name="Coder",
+        system_prompt="Write small Python functions.",
+        model_name="gpt-4o-mini",
+    ),
+]
+
+router = MultiAgentRouter(agents=agents)
+
+result = router.route_task("Write a function that adds two numbers")
+print("Chosen agent:", result["boss_decision"]["selected_agent"])
+```
+
+View the source on [GitHub](https://github.com/kyegomez/swarms/blob/master/examples/multi_agent/mar/multi_agent_router_minimal.py).

--- a/docs/swarms/structs/swarm_router.md
+++ b/docs/swarms/structs/swarm_router.md
@@ -419,6 +419,8 @@ multi_agent_router = SwarmRouter(
 result = multi_agent_router.run("Analyze the competitive landscape for our new product")
 ```
 
+See [MultiAgentRouter Minimal Example](../examples/multi_agent_router_minimal.md) for a lightweight demonstration.
+
 ### HierarchicalSwarm
 
 Use Case: Creating a hierarchical structure of agents with a director.

--- a/examples/multi_agent/mar/multi_agent_router_minimal.py
+++ b/examples/multi_agent/mar/multi_agent_router_minimal.py
@@ -1,0 +1,20 @@
+from swarms import Agent, MultiAgentRouter
+
+if __name__ == "__main__":
+    agents = [
+        Agent(
+            agent_name="Researcher",
+            system_prompt="Answer questions briefly.",
+            model_name="gpt-4o-mini",
+        ),
+        Agent(
+            agent_name="Coder",
+            system_prompt="Write small Python functions.",
+            model_name="gpt-4o-mini",
+        ),
+    ]
+
+    router = MultiAgentRouter(agents=agents)
+
+    result = router.route_task("Write a function that adds two numbers")
+    print("Chosen agent:", result["boss_decision"]["selected_agent"])


### PR DESCRIPTION
## Summary
- add a simple example showing how to route a task with MultiAgentRouter
- document the example under examples
- link the new example in SwarmRouter docs
- list MultiAgentRouter in the routing architectures table
- reference the example in mkdocs nav
- use gpt-4o-mini instead of gpt-4o in the example

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68519074b6b4832981d07c415542e00d