### PR TITLE
Fix MCP event loop conflicts

### DIFF
--- a/tests/tools/test_mcp_event_loop.py
+++ b/tests/tools/test_mcp_event_loop.py
@@ -1,0 +1,14 @@
+import asyncio
+from unittest.mock import patch
+from swarms.tools import mcp_client_call
+
+async def _fake_aget_mcp_tools(*args, **kwargs):
+    return [{"name": "mock"}]
+
+def test_get_mcp_tools_sync_running_loop():
+    with patch.object(mcp_client_call, "aget_mcp_tools", side_effect=_fake_aget_mcp_tools):
+        async def main():
+            tools = mcp_client_call.get_mcp_tools_sync(server_path="http://dummy")
+            assert tools == [{"name": "mock"}]
+        asyncio.run(main())
+


### PR DESCRIPTION
## Summary
- guard `get_or_create_event_loop` against running loops
- use the safer loop helper when executing MCP tools
- add regression test for calling `get_mcp_tools_sync` inside a running loop

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68519ede534c8329bab2780be118b8b5

<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--41.org.readthedocs.build/en/41/

<!-- readthedocs-preview swarms end -->