### PR TITLE
Add ReasoningDuo batch example

### DIFF
--- a/docs/swarms/agents/reasoning_duo.md
+++ b/docs/swarms/agents/reasoning_duo.md
@@ -156,3 +156,7 @@ logger.info("Task processing started")
 - Processing time may vary based on task complexity
 - Model response quality depends on input clarity
 - Resource usage scales with batch size
+
+## Example Script
+
+For a runnable demonstration, see the [reasoning_duo_batched.py](https://github.com/kyegomez/swarms/blob/master/examples/models/reasoning_duo_batched.py) example.

--- a/examples/models/reasoning_duo_batched.py
+++ b/examples/models/reasoning_duo_batched.py
@@ -1,0 +1,19 @@
+from swarms.agents.reasoning_duo import ReasoningDuo
+
+if __name__ == "__main__":
+    # Initialize the ReasoningDuo with two lightweight models
+    duo = ReasoningDuo(
+        model_names=["gpt-4o-mini", "gpt-4o-mini"],
+        max_loops=1,
+    )
+
+    # Batched tasks to process
+    tasks = [
+        "Summarize the benefits of solar energy.",
+        "List three uses of robotics in healthcare.",
+    ]
+
+    # Run the batch once and print each result
+    results = duo.batched_run(tasks)
+    for task, output in zip(tasks, results):
+        print(f"Task: {task}\nResult: {output}\n")


### PR DESCRIPTION
## Summary
- add `reasoning_duo_batched.py` with two small models
- document example link in `ReasoningDuo` guide

