### PR TITLE
Update MCP usage in docs and tests

### DIFF
--- a/docs/examples/multi_mcp_execution.md
+++ b/docs/examples/multi_mcp_execution.md
@@ -21,14 +21,10 @@ agent = Agent(
     agent_name="Multi-MCP-Agent",
     model_name="gpt-4o-mini",
     max_loops=1,
+    mcp_urls=["http://localhost:8000/sse", "http://localhost:9001/sse"],
 )
 
-# Example JSON payloads produced by your model
-response = json.dumps([
-    {"function_name": "get_weather", "server_url": "http://localhost:8000/sse", "payload": {"city": "London"}},
-    {"function_name": "get_news", "server_url": "http://localhost:9001/sse", "payload": {"topic": "ai"}},
-])
-
-agent.handle_multiple_mcp_tools(agent.mcp_urls, response)
+# The agent will automatically dispatch requests to both MCP servers
+agent.run("Call both MCP servers")
 
 ```

--- a/docs/swarms/structs/agent.md
+++ b/docs/swarms/structs/agent.md
@@ -502,24 +502,11 @@ agent = Agent(
     agent_name="Multi-MCP-Agent",
     model_name="gpt-4o-mini",
     max_loops=1,
+    mcp_urls=["http://localhost:8000/sse", "http://localhost:9001/sse"],
 )
 
-# Example MCP payloads returned by your model
-mcp_response = json.dumps([
-
-    {
-        "function_name": "get_price",
-        "server_url": "http://localhost:8000/sse",
-        "payload": {"symbol": "BTC"},
-    },
-    {
-        "function_name": "market_sentiment",
-        "server_url": "http://localhost:9001/sse",
-        "payload": {"symbol": "BTC"},
-    },
-])
-
-agent.handle_multiple_mcp_tools(agent.mcp_urls, mcp_response)
+# Simply call run and the agent will reach out to both servers
+agent.run("Call both MCP servers")
 
 ```
 

--- a/docs/swarms/structs/agent_mcp.md
+++ b/docs/swarms/structs/agent_mcp.md
@@ -142,8 +142,8 @@ payload in the following format:
 ]
 ```
 
-Use `handle_multiple_mcp_tools` to execute each payload across the configured
-servers.
+When `mcp_urls` are provided, simply calling `agent.run()` will execute each
+payload across the configured servers.
 
 Example servers can be started with:
 

--- a/examples/tools/mcp_examples/tests/test_multi_mcp_demo.py
+++ b/examples/tools/mcp_examples/tests/test_multi_mcp_demo.py
@@ -27,25 +27,9 @@ def test_direct_tool_execution():
         max_loops=1
     )
     
-    # Create JSON payloads for multiple tools
-    payloads = [
-        {
-            "function_name": "get_weather", 
-            "server_url": "http://localhost:8000/sse",
-            "payload": {"city": "Paris"}
-        },
-        {
-            "function_name": "get_news", 
-            "server_url": "http://localhost:9001/sse",
-            "payload": {"topic": "science"}
-        }
-    ]
-    
     # Execute the tools and capture output
     print("Executing tools on multiple MCP servers...")
-    output = capture_output(
-        lambda: agent.handle_multiple_mcp_tools(agent.mcp_urls, json.dumps(payloads))
-    )
+    output = capture_output(lambda: agent.run("Call both MCP servers"))
     
     # Extract and display results
     print("\nResults from MCP tools:")

--- a/tests/structs/test_multi_mcp.py
+++ b/tests/structs/test_multi_mcp.py
@@ -1,14 +1,14 @@
 import asyncio
 import json
 from swarms.structs.agent import Agent, extract_json_from_response
-
 from swarms.structs.agent import execute_mcp_call
 from unittest.mock import patch
 
 
-def test_handle_multiple_mcp_tools():
-    agent = Agent(agent_name="Test", llm=None, max_loops=1)
+def test_run_with_multiple_mcp_urls():
     urls = ["http://server1", "http://server2"]
+    agent = Agent(agent_name="Test", llm=None, max_loops=1, mcp_urls=urls)
+
     payloads = [
         {
             "function_name": "tool1",
@@ -23,16 +23,15 @@ def test_handle_multiple_mcp_tools():
     ]
     called = []
 
-    async def fake_exec(
-        function_name, server_url, payload, *args, **kwargs
-    ):
+    async def fake_exec(function_name, server_url, payload, *args, **kwargs):
         called.append((function_name, server_url, payload))
         return "ok"
 
     with patch(
         "swarms.structs.agent.execute_mcp_call", side_effect=fake_exec
     ):
-        agent.handle_multiple_mcp_tools(urls, json.dumps(payloads))
+        agent.call_llm = lambda *args, **kwargs: json.dumps(payloads)
+        agent.run("test")
 
     assert called == [
         ("tool1", "http://server1", {"a": 1}),


### PR DESCRIPTION
## Summary
- update docs to show that agents automatically handle multiple MCP URLs
- adjust examples and tests to use `agent.run` instead of `handle_multiple_mcp_tools`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_685416db38fc8329ba3113f36ab2df40