### PR TITLE
Add onboarding CLI example

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,26 @@ ANTHROPIC_API_KEY=""
 GROQ_API_KEY=""
 ```
 
-- [Learn more about the environment configuration here](https://docs.swarms.world/en/latest/swarms/install/env/)
+ - [Learn more about the environment configuration here](https://docs.swarms.world/en/latest/swarms/install/env/)
+
+### CLI Onboarding Example
+
+Run the onboarding workflow directly from Python:
+
+```bash
+python -m swarms.cli.main onboarding
+```
+
+You will be prompted for:
+
+```
+Enter your first name (or type 'quit' to exit):
+Enter your Last Name (or type 'quit' to exit):
+Enter your email (or type 'quit' to exit):
+Enter your WORKSPACE_DIR: This is where logs, errors, and agent configurations will be stored (or type 'quit' to exit). Remember to set this as an environment variable: https://docs.swarms.world/en/latest/swarms/install/quickstart/ ||
+```
+
+This information is saved to `user_data.json` and cached for future runs.
 
 ---
 

--- a/docs/swarms/cli/main.md
+++ b/docs/swarms/cli/main.md
@@ -59,9 +59,11 @@ Below is a detailed explanation of the available commands:
   Starts the onboarding process to help you set up your environment and configure your agents.
   
   Usage:
-  ```bash
-  swarms onboarding
-  ```
+```bash
+swarms onboarding
+```
+
+For a step-by-step demonstration, see the [CLI Onboarding Example](../../README.md#cli-onboarding-example).
 
 - **help**  
   Displays the help message, including a list of available commands.


### PR DESCRIPTION
## Summary
- document how to launch `swarms.cli.main` with the onboarding command
- cross-link README onboarding example from CLI docs
