### PR TITLE
Add basic GraphWorkflow example

### DIFF
--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -60,6 +60,7 @@ Additionally, we have more comprehensive examples available in [The Swarms Cookb
 | Concurrent | [Concurrent Swarm](https://github.com/The-Swarm-Corporation/swarms-examples/blob/main/examples/structs/swarms/concurrent_swarm/concurrent_swarm_example.py) | Parallel execution of tasks across multiple agents for improved performance |
 | Star | [Star Swarm](https://github.com/The-Swarm-Corporation/swarms-examples/blob/main/examples/structs/swarms/different_architectures/star_swarm.py) | Centralized architecture with a hub agent coordinating peripheral agents |
 | Circular | [Circular Swarm](https://github.com/The-Swarm-Corporation/swarms-examples/blob/main/examples/structs/swarms/different_architectures/circular_swarm.py) | Ring topology for cyclic information flow between agents |
+| Graph Workflow | [Graph Workflow Basic](https://github.com/kyegomez/swarms/blob/main/examples/structs/graph_workflow_basic.py) | Minimal graph workflow with two agents and one task |
 
 ### Experimental Architectures
 | Category | Example | Description |

--- a/examples/structs/graph_workflow_basic.py
+++ b/examples/structs/graph_workflow_basic.py
@@ -1,0 +1,50 @@
+from swarms import Agent, Edge, GraphWorkflow, Node, NodeType
+
+
+def sample_task():
+    """Simple callable task."""
+    print("Running sample task")
+    return "Task completed"
+
+
+if __name__ == "__main__":
+    # Initialize two basic agents
+    agent1 = Agent(
+        agent_name="Agent1",
+        model_name="openai/gpt-4o-mini",
+        temperature=0.5,
+        max_tokens=4000,
+        max_loops=1,
+        autosave=True,
+        dashboard=True,
+    )
+
+    agent2 = Agent(
+        agent_name="Agent2",
+        model_name="openai/gpt-4o-mini",
+        temperature=0.5,
+        max_tokens=4000,
+        max_loops=1,
+        autosave=True,
+        dashboard=True,
+    )
+
+    # Build the workflow graph
+    wf_graph = GraphWorkflow()
+    wf_graph.add_node(Node(id="agent1", type=NodeType.AGENT, agent=agent1))
+    wf_graph.add_node(Node(id="agent2", type=NodeType.AGENT, agent=agent2))
+    wf_graph.add_node(Node(id="task1", type=NodeType.TASK, callable=sample_task))
+
+    wf_graph.add_edge(Edge(source="agent1", target="task1"))
+    wf_graph.add_edge(Edge(source="agent2", target="task1"))
+
+    wf_graph.set_entry_points(["agent1", "agent2"])
+    wf_graph.set_end_points(["task1"])
+
+    # Optional visualization in Mermaid format
+    print(wf_graph.visualize())
+
+    # Execute the graph
+    results = wf_graph.run()
+    print("Execution results:", results)
+


### PR DESCRIPTION
## Summary
- add a minimal GraphWorkflow example with two agents and one task
- link the new example in the docs examples index

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_685428596a6083299147a241c74cc358

<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--48.org.readthedocs.build/en/48/

<!-- readthedocs-preview swarms end -->