### PR TITLE
Fix event loop handling in MCP client

### DIFF
--- a/tests/tools/test_mcp_client_call.py
+++ b/tests/tools/test_mcp_client_call.py
@@ -1,0 +1,15 @@
+import asyncio
+import pytest
+
+from swarms.tools import mcp_client_call
+
+
+@pytest.mark.asyncio
+async def test_get_mcp_tools_sync_with_running_loop(monkeypatch):
+    async def fake_get(*args, **kwargs):
+        return [{"name": "mock"}]
+
+    monkeypatch.setattr(mcp_client_call, "aget_mcp_tools", fake_get)
+
+    result = mcp_client_call.get_mcp_tools_sync(server_path="dummy")
+    assert result == [{"name": "mock"}]


### PR DESCRIPTION
## Summary
- handle running event loops in `get_or_create_event_loop`
- add regression test for loop handling in MCP utilities

## Testing
- `pytest -q tests/tools/test_mcp_client_call.py`
- `pytest -q` *(fails: 67 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685431545dc4832981449ed1b1746ecf